### PR TITLE
Fixed reshape in decompressor

### DIFF
--- a/compressai/models/stf.py
+++ b/compressai/models/stf.py
@@ -764,7 +764,7 @@ class SymmetricalTransFormer(CompressionModel):
             index = self.gaussian_conditional.build_indexes(scale)
 
             rv = decoder.decode_stream(index.reshape(-1).tolist(), cdf, cdf_lengths, offsets)
-            rv = torch.Tensor(rv).reshape(1, -1, y_shape[0], y_shape[1])
+            rv = torch.Tensor(rv).reshape(mu.shape)
             y_hat_slice = self.gaussian_conditional.dequantize(rv, mu)
 
 


### PR DESCRIPTION
There seems to be an error in a reshape in the decompressor of STF. The 'dequantization'-method will not run because of this reshaping.